### PR TITLE
Sidebar stuff and sessions

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -7,9 +7,13 @@ import {
     RssIcon,
 
 } from "@heroicons/react/outline";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 
 function Sidebar() {
+        const { data: session, status } = useSession();
+
+        console.log(session);
+
     return (
         <div className="text-gray-600 p-5 text-sm border-r border-gray-900">
             <div className="space-y-4">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,13 @@
 import '../styles/globals.css'
+import { SessionProvider } from "next-auth/react";
 
-function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+function MyApp({ Component, pageProps: {session, ...pageProps }}
+  ) {
+  return (
+  <SessionProvider session={session}>
+    <Component {...pageProps} />
+  </SessionProvider>
+  )
 }
 
 export default MyApp

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -41,7 +41,7 @@ export default NextAuth({
   ],
   secret: process.env.JWT_SECRET,
   pages: {
-    signIn: '/login'
+    signIn: "/login",
   },
   callbacks: {
     async jwt({ token, account, user }) {

--- a/pages/login.js
+++ b/pages/login.js
@@ -27,6 +27,6 @@ export async function getServerSideProps() {
     return {
         props: {
             providers,
-        },
+        }
     };
 }


### PR DESCRIPTION
Added a session provider to _app.js that renders around the app to allow the "logged in" state to persist throughout the session. If you console.log() the session and you're logged out you will see no username and no info, but if you are logged in you will see all user information including access token, refresh token, email and username. SUCCESS!!